### PR TITLE
cmake: Avoid linking openthread-platform-utils-static lib

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -101,8 +101,6 @@ elseif(CONFIG_OPENTHREAD_MTD)
 list(APPEND ot_libs openthread-mtd)
 endif()
 
-list(APPEND ot_libs openthread-platform-utils-static)
-
 zephyr_link_libraries(${ot_libs})
 
 endif()


### PR DESCRIPTION
openthread-platform-utils-static library contains OpenThread settings
implementation, which conflicts and is no longer needed with native
Zephyr settings implementation.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>