### PR TITLE
cmake: Fix incorrect default mbedTLS config for Zephyr

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -3,6 +3,7 @@ if(CONFIG_NET_L2_OPENTHREAD)
 # OpenThread options
 set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "Disable OpenThread samples")
 set(OT_BUILTIN_MBEDTLS OFF CACHE BOOL "Use Zephry's mbedTLS")
+set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "Use Zephyr's mbedTLS heap")
 set(OT_PLATFORM "zephyr" CACHE STRING "Zephyr as a target platform")
 
 if(CONFIG_OPENTHREAD_COMMISSIONER)


### PR DESCRIPTION
mbedTLS default configuration in OpenThread when building with CMake
changed in the recent upmerge. In result, cryptography worked
incorrectly, making it impossible to decrypt packets in wireshark for
instance.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>