### PR TITLE
cmake: fix C++ with newlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
     endif()
 
     set(OT_CFLAGS
-        $<$<COMPILE_LANGUAGE:C>:${OT_CFLAGS} -Wall -Wextra -Wshadow -Werror -pedantic-errors>
-        $<$<COMPILE_LANGUAGE:CXX>:${OT_FLAGS} -Wall -Wextra -Wshadow -Wno-c++14-compat -fno-exceptions>
+        $<$<COMPILE_LANGUAGE:C>:${OT_CFLAGS} -Wall -Wextra -Wshadow>
+        $<$<COMPILE_LANGUAGE:CXX>:${OT_FLAGS} -Wall -Wextra -Wshadow -Wno-c++14-compat -D__STDC_LIMIT_MACROS -fno-exceptions>
     )
 endif()
 


### PR DESCRIPTION
When compiling OpenThread within Zephyr and having the following config:

```
CONFIG_NEWLIB_LIBC=y
CONFIG_LIB_CPLUSPLUS=y
```

two problems appear:

1) UINT8_MAX etc. are not defined

```
/home/markus/src/wrp-n4m/modules/lib/openthread/src/ncp/ncp_base_mtd.cpp:
In member function 'otError ot::Ncp::NcpBase::HandlePropertyRemove()
[with unsigned int aKey = 161; otError = otError]':
/home/markus/src/wrp-n4m/modules/lib/openthread/src/ncp/ncp_base_mtd.cpp:898:39:
error: 'UINT8_MAX' was not declared in this scope; did you mean
'UINT_MAX'?
  898 |     VerifyOrExit(serviceDataLength <= UINT8_MAX, error =
OT_ERROR_INVALID_ARGS);
```

2) #include_next <stdint.h> is a warning that gets promoted to an error

```
In file included from
/home/markus/src/wrp-n4m/modules/lib/openthread/src/lib/spinel/spinel.h:316,
                 from
/home/markus/src/wrp-n4m/modules/lib/openthread/src/lib/spinel/spinel.c:46:
/home/markus/src/wrp-n4m/zephyr/lib/libc/newlib/include/stdint.h:28:2:
error: #include_next is a GCC extension
   28 | #include_next <stdint.h>
```

Work-arounds for

1) add `-D__STDC_LIMIT_MACROS` for C++
2) remove `-Werror -pedantic-errors` for C

Are there better fixes?

I am aware that the changes should go to the OpenThread repository, but
for the moment let's discuss here since it is an Zephyr issue right now.

Would it be possible to just patch the CMakeLists.txt?

Signed-off-by: Markus Becker <markus.becker@tridonic.com>