### PR TITLE
[cmake] Add config option to enable CoAP api

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -62,6 +62,9 @@ if(CONFIG_OPENTHREAD_UDP_FORWARD)
   set(OT_UDP_FORWARD ON CACHE BOOL "Enable UDP Forward")
 endif()
 
+if(CONFIG_OPENTHREAD_COAP)
+  set(OT_COAP ON CACHE BOOL "Enable CoAP api")
+endif()
 
 # Zephyr libc capabilies
 set(HAVE_STRLCPY OFF CACHE BOOL "Zephyr's minimal libc does not provide strlcpy")


### PR DESCRIPTION
So far there was no way to use OT CoAP api in zephyr application. These changes fix it.