### PR TITLE
CMake: Add a openthread ncp vendor hook

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -56,6 +56,10 @@ if(CONFIG_OPENTHREAD_NCP)
   set(OT_NCP ON CACHE BOOL "Enable Network Co-Processor NCP")
 endif()
 
+if(CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE)
+  set(OT_NCP_VENDOR_HOOK_SOURCE ${CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE} CACHE STRING "NCP vendor hook source file name")
+endif()
+
 if(CONFIG_OPENTHREAD_RCP)
   set(OT_RCP ON CACHE BOOL "Enable Network Co-Processor RCP")
 endif()


### PR DESCRIPTION
Add a openthread ncp vendor hook.

This pull request already includes a pull request from the openthread/openthread repo (https://github.com/zephyrproject-rtos/zephyr/pull/25450). As soon as that pull request is merged in the openhtread/openthread repo and openthread in this repo is updated, the commit 10650e2 can be dropped.