### PR TITLE
cmake: Allow multiple mbedtls libraries

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -7,9 +7,11 @@ set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "Disable OpenThread samples")
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "Use Zephyr's mbedTLS heap")
 set(OT_PLATFORM "zephyr" CACHE STRING "Zephyr as a target platform")
 
+string(REPLACE " " ";" OT_MBEDTLS_LIB_LIST " ${CONFIG_OPENTHREAD_MBEDTLS_LIB_NAME}")
+
 set(
     OT_EXTERNAL_MBEDTLS
-    ${CONFIG_OPENTHREAD_MBEDTLS_TARGET}
+    ${OT_MBEDTLS_LIB_LIST}
     CACHE STRING
     "Specify external mbedtls library"
 )


### PR DESCRIPTION
Some mbedtls implementations require multiple libraries to be linked,
for example nrf_security provides common + backend specific libraries.
Intorduced possibility of passing multiple libraries from project
configuration file.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>