### PR TITLE
openthread build flags

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -203,6 +203,14 @@ list(APPEND OT_PRIVATE_INCLUDES $ENV{ZEPHYR_BASE}/subsys/net/lib/openthread/plat
 # Need to specify build directory as well
 add_subdirectory(.. build)
 
+zephyr_get_targets(${CMAKE_CURRENT_LIST_DIR}/../ "STATIC_LIBRARY;OBJECT_LIBRARY" ALL_TARGETS)
+foreach(target ${ALL_TARGETS})
+  # We don't want to build all openthread libraries per default.
+  # Setting EXCLUDE_FROM_ALL ensures that only libraries that are linked
+  # into Zephyr will be built due to dependencies.
+  set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)
+endforeach()
+
 # Zephyr compiler options
 target_include_directories(ot-config INTERFACE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
@@ -219,12 +227,6 @@ target_compile_definitions(ot-config INTERFACE
 target_compile_options(ot-config INTERFACE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin
 )
-
-target_compile_options(openthread-platform-utils PRIVATE
-    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin
-)
-
-add_dependencies(openthread-platform-utils syscall_list_h_target)
 
 # Include OpenThread headers
 zephyr_system_include_directories(../include)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -198,7 +198,7 @@ add_definitions(
     -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-zephyr-config.h"
 )
 
-list(APPEND OT_PRIVATE_INCLUDES $ENV{ZEPHYR_BASE}/subsys/net/lib/openthread/platform)
+list(APPEND OT_PRIVATE_INCLUDES ${ZEPHYR_BASE}/subsys/net/lib/openthread/platform)
 
 # Need to specify build directory as well
 add_subdirectory(.. build)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -192,20 +192,6 @@ if(CONFIG_LOG_BACKEND_SPINEL)
   )
 endif()
 
-# Zephyr compiler options
-zephyr_get_compile_options_for_lang_as_string(C   c_options)
-zephyr_get_compile_options_for_lang_as_string(CXX cxx_options)
-
-set(c_options   "${c_options} -fno-builtin")
-set(cxx_options "${cxx_options} -fno-builtin")
-
-zephyr_get_include_directories_for_lang_as_string(       C includes)
-zephyr_get_system_include_directories_for_lang_as_string(C system_includes)
-
-set(CMAKE_C_FLAGS   "${c_options} ${includes} ${system_includes}")
-set(CMAKE_CXX_FLAGS "${cxx_options} ${includes} ${system_includes}")
-set(CMAKE_ASM_FLAGS "${c_options} ${includes} ${system_includes}")
-
 # Other options
 add_definitions(
     -DOPENTHREAD_CONFIG_LOG_LEVEL=${CONFIG_OPENTHREAD_LOG_LEVEL}
@@ -216,6 +202,29 @@ list(APPEND OT_PRIVATE_INCLUDES $ENV{ZEPHYR_BASE}/subsys/net/lib/openthread/plat
 
 # Need to specify build directory as well
 add_subdirectory(.. build)
+
+# Zephyr compiler options
+target_include_directories(ot-config INTERFACE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_include_directories(ot-config SYSTEM INTERFACE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(ot-config INTERFACE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>
+)
+
+target_compile_options(ot-config INTERFACE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin
+)
+
+target_compile_options(openthread-platform-utils PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin
+)
+
+add_dependencies(openthread-platform-utils syscall_list_h_target)
 
 # Include OpenThread headers
 zephyr_system_include_directories(../include)


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/28197

Using generator expressions to fetch include directories, compile
options, and compile definitions from Zephyr interface.

This fixes #28197 and is a safer approach because the use of a generator
expression ensures that properties added after openthread libraries are
defined will also be included.

zephyr_get_<option>_for_lang() has a limitation that it will not be able
to return flags added to zephyr_interface after the function has
returned.

It also disables unused openthread libraries from Zephyr build.
This removes the need of setting Zephyr compile flags on openthread
targets that are not used by Zephyr.

This reduces number of build steps and build time significantly.

Before, 780 steps:
`time ninja -Cbuild`
```
[708/708] Linking CXX executable zephyr/zephyr.elf
135.08user 30.24system 0:46.21elapsed 357%CPU
```

After, 480 steps:
`time ninja -Cbuild`
```
[480/480] Linking CXX executable zephyr/zephyr.elf
84.02user 18.92system 0:30.72elapsed 335%CPU
```

---------

Manifest PR: https://github.com/zephyrproject-rtos/zephyr/pull/28273
