### PR TITLE
cmake: Add C library dependency to ot-config target

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -245,6 +245,10 @@ target_compile_options(ot-config INTERFACE
 # errno_private.h is generated as part of ${SYSCALL_LIST_H_TARGET} target.
 add_dependencies(ot-config ${SYSCALL_LIST_H_TARGET})
 
+# Make sure C library is linked after OpenThread libraries (to prevent linker
+# errors)
+target_link_libraries(ot-config INTERFACE -lc)
+
 # Include OpenThread headers
 zephyr_system_include_directories(../include)
 zephyr_system_include_directories(../examples/platforms)
@@ -282,6 +286,6 @@ list(APPEND ot_libs openthread-mtd)
 endif()
 endif()
 
-zephyr_link_libraries(${ot_libs} -lc)
+zephyr_link_libraries(${ot_libs})
 
 endif()


### PR DESCRIPTION
Apparently linking `-lc` within `zephyr_link_library` did not ensure
that C library is linked after OpenThread libs, which in result could
lead to linker errors (for instance "undefined reference to
`isupper'").

Fix this by using `target_link_libraries` command on the ot-config
target instead, which is linked with every OT library generated.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>