### PR TITLE
cmake: Fix CONFIG_OPENTHREAD_CUSTOM_PARAMETERS handling

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -335,9 +335,6 @@ if(CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE)
   set(OT_NCP_VENDOR_HOOK_SOURCE ${CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE} CACHE STRING "NCP vendor hook source file name" FORCE)
 endif()
 
-string(REPLACE " " ";" OT_PARAM_LIST " ${CONFIG_OPENTHREAD_CUSTOM_PARAMETERS}")
-list(APPEND OT_PRIVATE_DEFINES ${OT_PARAM_LIST})
-
 # Zephyr logging options
 
 if(CONFIG_LOG_BACKEND_SPINEL)
@@ -352,8 +349,6 @@ add_definitions(
     -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-zephyr-config.h"
 )
 
-list(APPEND OT_PRIVATE_INCLUDES ${ZEPHYR_BASE}/subsys/net/lib/openthread/platform)
-
 # Need to specify build directory as well
 add_subdirectory(.. build)
 
@@ -364,6 +359,9 @@ foreach(target ${ALL_TARGETS})
   # into Zephyr will be built due to dependencies.
   set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)
 endforeach()
+
+string(REPLACE " " ";" OT_PARAM_LIST " ${CONFIG_OPENTHREAD_CUSTOM_PARAMETERS}")
+target_compile_definitions(ot-config INTERFACE ${OT_PARAM_LIST})
 
 # Zephyr compiler options
 target_include_directories(ot-config INTERFACE


### PR DESCRIPTION
Current handling of CONFIG_OPENTHREAD_CUSTOM_PARAMETERS config used an
a OT_PRIVATE_DEFINES variable, which became obsolete and no longer
functional due to some past changes in OpenThread build system. Use
`ot-config` target instead to pass custom configs.

Additionally, remove the line that appended the OT_PRIVATE_INCLUDES
variable, as the variable also became obsolete and is no longer used in
the OpenThread build system.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>