### PR TITLE
zephyr: Specify module's Kconfig location

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
   cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Specify that the Kconfig file for the OpenThread module is located
within Zephyr tree.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>