### PR TITLE
module: add security info to module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -30,3 +30,7 @@ name: openthread
 build:
   cmake-ext: True
   kconfig-ext: True
+security:
+  external-references:
+    - cpe:2.3:o:google:openthread:2023-07-06:*:*:*:*:*:*:*
+    - pkg:github/openthread/openthread@thread-reference-20230706


### PR DESCRIPTION
Add CPE and PURL references to module.yml file for use by Zephyr's SPDX generation tool.

See github issue in Zephyr repo: https://github.com/zephyrproject-rtos/zephyr/issues/53479

The CPE added is the most recent one I could find for openthread in the NIST database: https://nvd.nist.gov/products/cpe/detail/5F57440F-9CB1-4BA2-BD81-FA00F15C8441
